### PR TITLE
增加 autoload 的目录，避免composer的误判

### DIFF
--- a/bin/easywechat
+++ b/bin/easywechat
@@ -5,7 +5,13 @@ if (PHP_SAPI !== 'cli' || PHP_MAJOR_VERSION < 7) {
 }
 $loaded = false;
 
-foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php') as $file) {
+$try_autoload_files = array(
+    __DIR__ . '/../../../autoload.php', 
+    __DIR__ . '/../vendor/autoload.php', 
+    __DIR__ . '/../autoload.php',
+);
+
+foreach ($try_autoload_files as $file) {
     if (file_exists($file)) {
         require $file;
         $loaded = true;


### PR DESCRIPTION
增加了一个目录： ```__DIR__ . '/../autoload.php'```
在我的项目中，autoload文件是在 $project_root/vendor/autoload.php 中